### PR TITLE
design: QuestionList 페이지 Dropdown hover 효과 추가

### DIFF
--- a/src/components/questionlist/Dropdown.jsx
+++ b/src/components/questionlist/Dropdown.jsx
@@ -103,6 +103,23 @@ const DropdownButton = styled.button`
     ${({ $isOpen }) =>
       $isOpen ? 'var(--grayScale-60)' : 'var(--grayScale-40)'};
   border-radius: 8px;
+  transition:
+    border 0.3s ease-in-out,
+    color 0.3s ease-in-out;
+
+  svg path {
+    fill: var(--grayScale-40);
+    transition: 0.3s ease-in-out;
+  }
+
+  &:hover {
+    border-color: var(--grayScale-60);
+    color: var(--grayScale-60);
+
+    svg path {
+      fill: var(--grayScale-60);
+    }
+  }
 
   &:focus-visible {
     outline: 2px solid var(--blue-50);


### PR DESCRIPTION
## #️⃣연관된 이슈

design/#115

## 📝작업 내용

QuestionList 페이지 - Dropdown 컴포넌트에 hover 효과 추가

### 스크린샷 (선택)

호버 전
<img width="1063" height="305" alt="image" src="https://github.com/user-attachments/assets/4401d02f-88bd-4db0-abd2-65c8ecff927e" />


호버 후
<img width="1041" height="296" alt="image" src="https://github.com/user-attachments/assets/58bca79b-bcf6-4521-9a74-75e8c9740b0d" />

